### PR TITLE
Add TlutOffset to objects added by PR

### DIFF
--- a/assets/xml/objects/object_ane.xml
+++ b/assets/xml/objects/object_ane.xml
@@ -41,15 +41,15 @@
         <Texture Name="gCuccoLadyTLUT" OutName="tlut" Format="rgb5a1" Width="16" Height="16" Offset="0x0108"/>
 
         <!-- Textures -->
-        <Texture Name="gCuccoLadyHairTex" OutName="hair" Format="ci8" Width="8" Height="16" Offset="0x0308"/>
-        <Texture Name="gCuccoLadyTex_0388" OutName="tex_0388" Format="ci8" Width="8" Height="8" Offset="0x0388"/>
-        <Texture Name="gCuccoLadyEarTex" OutName="ear" Format="ci8" Width="16" Height="16" Offset="0x03C8"/>
+        <Texture Name="gCuccoLadyHairTex" OutName="hair" Format="ci8" Width="8" Height="16" Offset="0x0308" TlutOffset="0x0108"/>
+        <Texture Name="gCuccoLadyTex_0388" OutName="tex_0388" Format="ci8" Width="8" Height="8" Offset="0x0388" TlutOffset="0x0108"/>
+        <Texture Name="gCuccoLadyEarTex" OutName="ear" Format="ci8" Width="16" Height="16" Offset="0x03C8" TlutOffset="0x0108"/>
         <Texture Name="gCuccoLadyMouthTex" OutName="mouth" Format="rgb5a1" Width="32" Height="16" Offset="0x04C8"/>
-        <Texture Name="gCuccoLadyBackOfHandTex" OutName="back_of_hand" Format="ci8" Width="16" Height="16" Offset="0x20C8"/>
-        <Texture Name="gCuccoLadySleeveTex" OutName="sleeve" Format="ci8" Width="8" Height="16" Offset="0x21C8"/>
-        <Texture Name="gCuccoLadyShirtButtonTex" OutName="shirt_button" Format="ci8" Width="8" Height="8" Offset="0x2248"/>
-        <Texture Name="gCuccoLadyWaistTex" OutName="waist" Format="ci8" Width="16" Height="16" Offset="0x2288"/>
-        <Texture Name="gCuccoLadySkirtTex" OutName="skirt" Format="ci8" Width="32" Height="32" Offset="0x2388"/>
+        <Texture Name="gCuccoLadyBackOfHandTex" OutName="back_of_hand" Format="ci8" Width="16" Height="16" Offset="0x20C8" TlutOffset="0x0108"/>
+        <Texture Name="gCuccoLadySleeveTex" OutName="sleeve" Format="ci8" Width="8" Height="16" Offset="0x21C8" TlutOffset="0x0108"/>
+        <Texture Name="gCuccoLadyShirtButtonTex" OutName="shirt_button" Format="ci8" Width="8" Height="8" Offset="0x2248" TlutOffset="0x0108"/>
+        <Texture Name="gCuccoLadyWaistTex" OutName="waist" Format="ci8" Width="16" Height="16" Offset="0x2288" TlutOffset="0x0108"/>
+        <Texture Name="gCuccoLadySkirtTex" OutName="skirt" Format="ci8" Width="32" Height="32" Offset="0x2388" TlutOffset="0x0108"/>
 
         <!-- Eye Textures -->
         <Texture Name="gCuccoLadyEyeOpenTex" OutName="cucco_lady_eye_open" Format="rgb5a1" Width="32" Height="32" Offset="0x8C8"/>

--- a/assets/xml/objects/object_ani.xml
+++ b/assets/xml/objects/object_ani.xml
@@ -42,10 +42,10 @@
         <Texture Name="gRoofMan2TLUT" OutName="roof_man_2_tlut" Format="ci8" Width="16" Height="16" Offset="0x1088"/>
 
         <!-- Roof Man DisplayList Textures -->
-        <Texture Name="gRoofManHandBackTex" OutName="roof_man_hand_back" Format="ci8" Width="16" Height="16" Offset="0x00C08"/>
-        <Texture Name="gRoofManForearmGradientTex" OutName="roof_man_forearm_gradient" Format="ci8" Width="8" Height="8" Offset="0x00D08"/>
-        <Texture Name="gRoofManThighGradientTex" OutName="roof_man_thigh_gradient" Format="ci8" Width="8" Height="8" Offset="0x00D48"/>
-        <Texture Name="gRoofManSandalBuckleTex" OutName="roof_man_sandal_buckle" Format="ci8" Width="16" Height="16" Offset="0x00D88"/>
+        <Texture Name="gRoofManHandBackTex" OutName="roof_man_hand_back" Format="ci8" Width="16" Height="16" Offset="0x00C08" TlutOffset="0x00108"/>
+        <Texture Name="gRoofManForearmGradientTex" OutName="roof_man_forearm_gradient" Format="ci8" Width="8" Height="8" Offset="0x00D08" TlutOffset="0x00108"/>
+        <Texture Name="gRoofManThighGradientTex" OutName="roof_man_thigh_gradient" Format="ci8" Width="8" Height="8" Offset="0x00D48" TlutOffset="0x00108"/>
+        <Texture Name="gRoofManSandalBuckleTex" OutName="roof_man_sandal_buckle" Format="ci8" Width="16" Height="16" Offset="0x00D88" TlutOffset="0x00108"/>
         <Texture Name="gRoofManTrouserPatternTex" OutName="roof_man_trouser_pattern" Format="rgb5a1" Width="16" Height="16" Offset="0x00E88"/>
         <Texture Name="gRoofManSkinGradientTex" OutName="roof_man_skin_gradient" Format="ci8" Width="8" Height="8" Offset="0x012D8"/>
         <Texture Name="gRoofManEarTex" OutName="roof_man_ear" Format="ci8" Width="16" Height="16" Offset="0x01318"/>

--- a/assets/xml/objects/object_aob.xml
+++ b/assets/xml/objects/object_aob.xml
@@ -42,14 +42,14 @@
         <Texture Name="gDogLadyTLUT" OutName="tlut" Format="rgb5a1" Width="16" Height="16" Offset="0x0108"/>
 
         <!-- Textures -->
-        <Texture Name="gDogLadyHairTex" OutName="hair" Format="ci8" Width="16" Height="16" Offset="0x0308"/>
-        <Texture Name="gDogLadySkinGradientTex" OutName="skin_gradient" Format="ci8" Width="8" Height="8" Offset="0x0408"/>
-        <Texture Name="gDogLadyEarTex" OutName="ear" Format="ci8" Width="16" Height="16" Offset="0x0448"/>
-        <Texture Name="gDogLadyLipGradientTex" OutName="lip_gradient" Format="ci8" Width="8" Height="8" Offset="0x0548"/>
-        <Texture Name="gDogLadyNostrilTex" OutName="nostril" Format="ci8" Width="8" Height="8" Offset="0x0588"/>
-        <Texture Name="gDogLadyBackOfHandTex" OutName="back_of_hand" Format="ci8" Width="16" Height="16" Offset="0x1DC8"/>
-        <Texture Name="gDogLadyDressShoulderPatternTex" OutName="dress_shoulder_pattern" Format="ci8" Width="8" Height="8" Offset="0x1EC8"/>
-        <Texture Name="gDogLadyDressTex" OutName="dress" Format="ci8" Width="8" Height="8" Offset="0x1F08"/>
+        <Texture Name="gDogLadyHairTex" OutName="hair" Format="ci8" Width="16" Height="16" Offset="0x0308" TlutOffset="0x0108"/>
+        <Texture Name="gDogLadySkinGradientTex" OutName="skin_gradient" Format="ci8" Width="8" Height="8" Offset="0x0408" TlutOffset="0x0108"/>
+        <Texture Name="gDogLadyEarTex" OutName="ear" Format="ci8" Width="16" Height="16" Offset="0x0448" TlutOffset="0x0108"/>
+        <Texture Name="gDogLadyLipGradientTex" OutName="lip_gradient" Format="ci8" Width="8" Height="8" Offset="0x0548" TlutOffset="0x0108"/>
+        <Texture Name="gDogLadyNostrilTex" OutName="nostril" Format="ci8" Width="8" Height="8" Offset="0x0588" TlutOffset="0x0108"/>
+        <Texture Name="gDogLadyBackOfHandTex" OutName="back_of_hand" Format="ci8" Width="16" Height="16" Offset="0x1DC8" TlutOffset="0x0108"/>
+        <Texture Name="gDogLadyDressShoulderPatternTex" OutName="dress_shoulder_pattern" Format="ci8" Width="8" Height="8" Offset="0x1EC8" TlutOffset="0x0108"/>
+        <Texture Name="gDogLadyDressTex" OutName="dress" Format="ci8" Width="8" Height="8" Offset="0x1F08" TlutOffset="0x0108"/>
 
         <!-- Dog Lady Eye Textures -->
         <Texture Name="gDogLadyEyeOpenTex" OutName="dog_lady_eye_open" Format="rgb5a1" Width="32" Height="32" Offset="0x05C8"/>

--- a/assets/xml/objects/object_bdan_objects.xml
+++ b/assets/xml/objects/object_bdan_objects.xml
@@ -1,20 +1,20 @@
 <Root>
     <File Name="object_bdan_objects" Segment="6">
         <!-- Textures -->
-        <Texture Name="gJabuObjectsTex_00140" OutName="jabu_objects_tex_00000140" Format="ci8" Width="32" Height="32" Offset="0x0140"/>
-        <Texture Name="gJabuObjectsTex_007A0" OutName="jabu_objects_tex_000007A0" Format="ci8" Width="32" Height="32" Offset="0x07A0"/>
-        <Texture Name="gJabuObjectsTex_00E00" OutName="jabu_objects_tex_00000E00" Format="ci8" Width="32" Height="32" Offset="0x0E00"/>
-        <Texture Name="gJabuObjectsTex_01460" OutName="jabu_objects_tex_00001460" Format="ci8" Width="32" Height="32" Offset="0x1460"/>
-        <Texture Name="gJabuObjectsTex_01AC0" OutName="jabu_objects_tex_00001AC0" Format="ci8" Width="32" Height="32" Offset="0x1AC0"/>
-        <Texture Name="gJabuObjectsTex_02120" OutName="jabu_objects_tex_00002120" Format="ci8" Width="32" Height="32" Offset="0x2120"/>
-        <Texture Name="gJabuObjectsTex_02780" OutName="jabu_objects_tex_00002780" Format="ci8" Width="32" Height="32" Offset="0x2780"/>
-        <Texture Name="gJabuObjectsTex_02DE0" OutName="jabu_objects_tex_00002DE0" Format="ci8" Width="32" Height="32" Offset="0x2DE0"/>
-        <Texture Name="gJabuObjectsTex_03498" OutName="jabu_objects_tex_00003498" Format="ci8" Width="32" Height="32" Offset="0x3498"/>
-        <Texture Name="gJabuObjectsTex_03BB8" OutName="jabu_objects_tex_00003BB8" Format="ci8" Width="32" Height="64" Offset="0x3BB8"/>
-        <Texture Name="gJabuObjectsTex_043B8" OutName="jabu_objects_tex_000043B8" Format="ci8" Width="32" Height="32" Offset="0x43B8"/>
-        <Texture Name="gJabuObjectsTex_06748" OutName="jabu_objects_tex_00006748" Format="ci8" Width="32" Height="32" Offset="0x6748"/>
-        <Texture Name="gJabuObjectsTex_06B48" OutName="jabu_objects_tex_00006B48" Format="ci8" Width="32" Height="64" Offset="0x6B48"/>
-        <Texture Name="gJabuObjectsTex_07348" OutName="jabu_objects_tex_00007348" Format="ci8" Width="32" Height="64" Offset="0x7348"/>
+        <Texture Name="gJabuObjectsTex_00140" OutName="jabu_objects_tex_00000140" Format="ci8" Width="32" Height="32" Offset="0x0140" TlutOffset="0x0000"/>
+        <Texture Name="gJabuObjectsTex_007A0" OutName="jabu_objects_tex_000007A0" Format="ci8" Width="32" Height="32" Offset="0x07A0" TlutOffset="0x0660"/>
+        <Texture Name="gJabuObjectsTex_00E00" OutName="jabu_objects_tex_00000E00" Format="ci8" Width="32" Height="32" Offset="0x0E00" TlutOffset="0x0CC0"/>
+        <Texture Name="gJabuObjectsTex_01460" OutName="jabu_objects_tex_00001460" Format="ci8" Width="32" Height="32" Offset="0x1460" TlutOffset="0x1320"/>
+        <Texture Name="gJabuObjectsTex_01AC0" OutName="jabu_objects_tex_00001AC0" Format="ci8" Width="32" Height="32" Offset="0x1AC0" TlutOffset="0x1980"/>
+        <Texture Name="gJabuObjectsTex_02120" OutName="jabu_objects_tex_00002120" Format="ci8" Width="32" Height="32" Offset="0x2120" TlutOffset="0x1FE0"/>
+        <Texture Name="gJabuObjectsTex_02780" OutName="jabu_objects_tex_00002780" Format="ci8" Width="32" Height="32" Offset="0x2780" TlutOffset="0x2640"/>
+        <Texture Name="gJabuObjectsTex_02DE0" OutName="jabu_objects_tex_00002DE0" Format="ci8" Width="32" Height="32" Offset="0x2DE0" TlutOffset="0x2CA0"/>
+        <Texture Name="gJabuObjectsTex_03498" OutName="jabu_objects_tex_00003498" Format="ci8" Width="32" Height="32" Offset="0x3498" TlutOffset="0x3300"/>
+        <Texture Name="gJabuObjectsTex_03BB8" OutName="jabu_objects_tex_00003BB8" Format="ci8" Width="32" Height="64" Offset="0x3BB8" TlutOffset="0x39B0"/>
+        <Texture Name="gJabuObjectsTex_043B8" OutName="jabu_objects_tex_000043B8" Format="ci8" Width="32" Height="32" Offset="0x43B8" TlutOffset="0x39B0"/>
+        <Texture Name="gJabuObjectsTex_06748" OutName="jabu_objects_tex_00006748" Format="ci8" Width="32" Height="32" Offset="0x6748" TlutOffset="0x6540"/>
+        <Texture Name="gJabuObjectsTex_06B48" OutName="jabu_objects_tex_00006B48" Format="ci8" Width="32" Height="64" Offset="0x6B48" TlutOffset="0x6540"/>
+        <Texture Name="gJabuObjectsTex_07348" OutName="jabu_objects_tex_00007348" Format="ci8" Width="32" Height="64" Offset="0x7348" TlutOffset="0x6540"/>
         <Texture Name="gJabuObjectsTex_08D10" OutName="jabu_objects_tex_00008D10" Format="rgb5a1" Width="32" Height="64" Offset="0x8D10"/>
         <Texture Name="gJabuObjectsTex_09D10" OutName="jabu_objects_tex_00009D10" Format="rgb5a1" Width="32" Height="32" Offset="0x9D10"/>
         <Texture Name="gJabuObjectsTex_0A510" OutName="jabu_objects_tex_0000A510" Format="rgb5a1" Width="32" Height="64" Offset="0xA510"/>

--- a/assets/xml/objects/object_cow.xml
+++ b/assets/xml/objects/object_cow.xml
@@ -44,12 +44,12 @@
         <Texture Name="gCowTLUT" OutName="cow_tlut" Format="rgb5a1" Width="16" Height="16" Offset="0x2880"/>
 
         <!-- Cow DisplayList Textures -->
-        <Texture Name="gCowUdderTex" OutName="cow_udder" Format="ci8" Width="16" Height="16" Offset="0x2A80"/>
-        <Texture Name="gCowNoseRingTex" OutName="cow_nose_ring" Format="ci8" Width="8" Height="8" Offset="0x2B80"/>
-        <Texture Name="gCowNoseTex" OutName="cow_nose" Format="ci8" Width="16" Height="16" Offset="0x2BC0"/>
+        <Texture Name="gCowUdderTex" OutName="cow_udder" Format="ci8" Width="16" Height="16" Offset="0x2A80" TlutOffset="0x2880"/>
+        <Texture Name="gCowNoseRingTex" OutName="cow_nose_ring" Format="ci8" Width="8" Height="8" Offset="0x2B80" TlutOffset="0x2880"/>
+        <Texture Name="gCowNoseTex" OutName="cow_nose" Format="ci8" Width="16" Height="16" Offset="0x2BC0" TlutOffset="0x2880"/>
         <Texture Name="gCowSpottedPatternTex" OutName="cow_spotted_pattern" Format="i8" Width="64" Height="64" Offset="0x2CC0"/>
-        <Texture Name="gCowEarTex" OutName="cow_ear" Format="ci8" Width="8" Height="16" Offset="0x3CC0"/>
+        <Texture Name="gCowEarTex" OutName="cow_ear" Format="ci8" Width="8" Height="16" Offset="0x3CC0" TlutOffset="0x2880"/>
         <Texture Name="gCowEyelidTex" OutName="cow_eyelid" Format="rgb5a1" Width="16" Height="16" Offset="0x3D40"/>
-        <Texture Name="gCowTailTex" OutName="cow_tail" Format="ci8" Width="8" Height="16" Offset="0x3F40"/>
+        <Texture Name="gCowTailTex" OutName="cow_tail" Format="ci8" Width="8" Height="16" Offset="0x3F40" TlutOffset="0x2880"/>
     </File>
 </Root>

--- a/assets/xml/objects/object_ddan_objects.xml
+++ b/assets/xml/objects/object_ddan_objects.xml
@@ -1,11 +1,11 @@
 <Root>
     <File Name="object_ddan_objects" Segment="6">
         <!-- Dodongo's Cavern DisplayList Textures -->
-        <Texture Name="gDodongoTex_0410" OutName="tex_0410" Format="ci8" Width="32" Height="64" Offset="0x0410"/>
-        <Texture Name="gDodongoRisingPlatformSide1Tex" OutName="rising_platform_side_1" Format="ci8" Width="32" Height="64" Offset="0x2018"/>
-        <Texture Name="gDodongoRisingPlatformTopTex" OutName="rising_platform_top" Format="ci8" Width="32" Height="32" Offset="0x2818"/>
-        <Texture Name="gDodongoRisingPlatformSide2Tex" OutName="rising_platform_side_2" Format="ci8" Width="32" Height="64" Offset="0x2C18"/>
-        <Texture Name="gDodongoFallingStairsTex" OutName="falling_stairs" Format="ci8" Width="32" Height="32" Offset="0x3F18"/>
+        <Texture Name="gDodongoTex_0410" OutName="tex_0410" Format="ci8" Width="32" Height="64" Offset="0x0410" TlutOffset="0x02D0"/>
+        <Texture Name="gDodongoRisingPlatformSide1Tex" OutName="rising_platform_side_1" Format="ci8" Width="32" Height="64" Offset="0x2018" TlutOffset="0x1E10"/>
+        <Texture Name="gDodongoRisingPlatformTopTex" OutName="rising_platform_top" Format="ci8" Width="32" Height="32" Offset="0x2818" TlutOffset="0x1E10"/>
+        <Texture Name="gDodongoRisingPlatformSide2Tex" OutName="rising_platform_side_2" Format="ci8" Width="32" Height="64" Offset="0x2C18" TlutOffset="0x1E10"/>
+        <Texture Name="gDodongoFallingStairsTex" OutName="falling_stairs" Format="ci8" Width="32" Height="32" Offset="0x3F18" TlutOffset="0x3D10"/>
         <Texture Name="gDodongoDoorLeftSideTex" OutName="door_left_side" Format="rgb5a1" Width="32" Height="64" Offset="0x4F60"/>
         <Texture Name="gDodongoBarsTex" OutName="door_bars" Format="rgb5a1" Width="32" Height="32" Offset="0x5F60"/>
         <Texture Name="gDodongoBarsBottomTex" OutName="door_bars_bottom" Format="rgb5a1" Width="32" Height="32" Offset="0x6760"/>

--- a/assets/xml/objects/object_ds.xml
+++ b/assets/xml/objects/object_ds.xml
@@ -20,17 +20,17 @@
         <Texture Name="gPotionShopLadyTLUT" OutName="potion_shop_lady_tlut" Format="rgb5a1" Width="16" Height="16" Offset="0x3918"/>
 
         <!-- Potion Shop Lady DisplayList Textures -->
-        <Texture Name="gPotionShopLadySkinGradientTex" OutName="skin_gradient" Format="ci8" Width="8" Height="8" Offset="0x3B18"/>
-        <Texture Name="gPotionShopLadyEyelashBottomTex" OutName="eyelash_bottom" Format="ci8" Width="16" Height="8" Offset="0x3B58"/>
-        <Texture Name="gPotionShopLadyEyelashTopTex" OutName="eyelash_top" Format="ci8" Width="16" Height="8" Offset="0x3BD8"/>
-        <Texture Name="gPotionShopLadyEar1Tex" OutName="ear_1" Format="ci8" Width="16" Height="16" Offset="0x3C58"/>
-        <Texture Name="gPotionShopLadyHairTex" OutName="hair" Format="ci8" Width="16" Height="32" Offset="0x3D58"/>
-        <Texture Name="gPotionShopLadyEyeTex" OutName="eye" Format="ci8" Width="16" Height="8" Offset="0x3F58"/>
-        <Texture Name="gPotionShopLadyEar2Tex" OutName="ear_2" Format="ci8" Width="16" Height="16" Offset="0x3FD8"/>
-        <Texture Name="gPotionShopLadyArmGradientTex" OutName="arm_gradient" Format="ci8" Width="8" Height="8" Offset="0x40D8"/>
-        <Texture Name="gPotionShopLadyShirtPatternTex" OutName="shirt_pattern" Format="ci8" Width="16" Height="16" Offset="0x4118"/>
-        <Texture Name="gPotionShopLadyCatPattern1Tex" OutName="cat_pattern_1" Format="ci8" Width="32" Height="32" Offset="0x4218"/>
-        <Texture Name="gPotionShopLadyCatPattern2Tex" OutName="cat_pattern_2" Format="ci8" Width="16" Height="16" Offset="0x4618"/>
+        <Texture Name="gPotionShopLadySkinGradientTex" OutName="skin_gradient" Format="ci8" Width="8" Height="8" Offset="0x3B18" TlutOffset="0x3918"/>
+        <Texture Name="gPotionShopLadyEyelashBottomTex" OutName="eyelash_bottom" Format="ci8" Width="16" Height="8" Offset="0x3B58" TlutOffset="0x3918"/>
+        <Texture Name="gPotionShopLadyEyelashTopTex" OutName="eyelash_top" Format="ci8" Width="16" Height="8" Offset="0x3BD8" TlutOffset="0x3918"/>
+        <Texture Name="gPotionShopLadyEar1Tex" OutName="ear_1" Format="ci8" Width="16" Height="16" Offset="0x3C58" TlutOffset="0x3918"/>
+        <Texture Name="gPotionShopLadyHairTex" OutName="hair" Format="ci8" Width="16" Height="32" Offset="0x3D58" TlutOffset="0x3918"/>
+        <Texture Name="gPotionShopLadyEyeTex" OutName="eye" Format="ci8" Width="16" Height="8" Offset="0x3F58" TlutOffset="0x3918"/>
+        <Texture Name="gPotionShopLadyEar2Tex" OutName="ear_2" Format="ci8" Width="16" Height="16" Offset="0x3FD8" TlutOffset="0x3918"/>
+        <Texture Name="gPotionShopLadyArmGradientTex" OutName="arm_gradient" Format="ci8" Width="8" Height="8" Offset="0x40D8" TlutOffset="0x3918"/>
+        <Texture Name="gPotionShopLadyShirtPatternTex" OutName="shirt_pattern" Format="ci8" Width="16" Height="16" Offset="0x4118" TlutOffset="0x3918"/>
+        <Texture Name="gPotionShopLadyCatPattern1Tex" OutName="cat_pattern_1" Format="ci8" Width="32" Height="32" Offset="0x4218" TlutOffset="0x3918"/>
+        <Texture Name="gPotionShopLadyCatPattern2Tex" OutName="cat_pattern_2" Format="ci8" Width="16" Height="16" Offset="0x4618" TlutOffset="0x3918"/>
         
         <!-- Potion Shop Lady Animations-->
         <Animation Name="gPotionShopLadyAnim" Offset="0x39C"/>

--- a/assets/xml/objects/object_dy_obj.xml
+++ b/assets/xml/objects/object_dy_obj.xml
@@ -78,15 +78,15 @@
         <Texture Name="gGreatFairyBetaGradient2Tex" OutName="beta_gradient_2" Format="rgb5a1" Width="32" Height="32" Offset="0x8EB0"/>
         <Texture Name="gGreatFairyBetaClothesTex" OutName="beta_clothes" Format="rgb5a1" Width="16" Height="16" Offset="0x96B0"/>
         <Texture Name="gGreatFairyFlowerTex" OutName="flower" Format="ia16" Width="32" Height="32" Offset="0x98B0"/>
-        <Texture Name="gGreatFairyBootPatternTex" OutName="boot_pattern" Format="ci8" Width="32" Height="64" Offset="0x167F0"/>
-        <Texture Name="gGreatFairyLeavesPattern1Tex" OutName="leaves_pattern_1" Format="ci8" Width="32" Height="32" Offset="0x16FF0"/>
-        <Texture Name="gGreatFairySkinGradient" OutName="skin_gradient" Format="ci8" Width="8" Height="8" Offset="0x173F0"/>
+        <Texture Name="gGreatFairyBootPatternTex" OutName="boot_pattern" Format="ci8" Width="32" Height="64" Offset="0x167F0" TlutOffset="0x165F0"/>
+        <Texture Name="gGreatFairyLeavesPattern1Tex" OutName="leaves_pattern_1" Format="ci8" Width="32" Height="32" Offset="0x16FF0" TlutOffset="0x165F0"/>
+        <Texture Name="gGreatFairySkinGradient" OutName="skin_gradient" Format="ci8" Width="8" Height="8" Offset="0x173F0" TlutOffset="0x165F0"/>
         <Texture Name="gGreatFairyLeavesPattern2Tex" OutName="leaves_pattern_2" Format="rgb5a1" Width="32" Height="16" Offset="0x17430"/>
-        <Texture Name="gGreatFairyHairTex" OutName="hair" Format="ci8" Width="16" Height="16" Offset="0x17830"/>
-        <Texture Name="gGreatFairyEar1Tex" OutName="ear_1" Format="ci8" Width="8" Height="8" Offset="0x1B130"/>
-        <Texture Name="gGreatFairyEar2Tex" OutName="ear_2" Format="ci8" Width="8" Height="8" Offset="0x1B170"/>
-        <Texture Name="gGreatFairyBackOfHandTex" OutName="back_of_hand" Format="ci8" Width="16" Height="16" Offset="0x1B1B0"/>
-        <Texture Name="gGreatFairyLeavesPattern3Tex" OutName="leaves_pattern_3" Format="ci8" Width="32" Height="32" Offset="0x1B2B0"/>
+        <Texture Name="gGreatFairyHairTex" OutName="hair" Format="ci8" Width="16" Height="16" Offset="0x17830" TlutOffset="0x165F0"/>
+        <Texture Name="gGreatFairyEar1Tex" OutName="ear_1" Format="ci8" Width="8" Height="8" Offset="0x1B130" TlutOffset="0x165F0"/>
+        <Texture Name="gGreatFairyEar2Tex" OutName="ear_2" Format="ci8" Width="8" Height="8" Offset="0x1B170" TlutOffset="0x165F0"/>
+        <Texture Name="gGreatFairyBackOfHandTex" OutName="back_of_hand" Format="ci8" Width="16" Height="16" Offset="0x1B1B0" TlutOffset="0x165F0"/>
+        <Texture Name="gGreatFairyLeavesPattern3Tex" OutName="leaves_pattern_3" Format="ci8" Width="32" Height="32" Offset="0x1B2B0" TlutOffset="0x165F0"/>
         <Texture Name="gGreatFairySpiralBeamPatternTex" OutName="spiral_beam_pattern" Format="i8" Width="16" Height="16" Offset="0x1B6B0"/>
         <Texture Name="gGreatFairySpiralBeamGradientTex" OutName="spiral_beam_gradient" Format="i8" Width="32" Height="64" Offset="0x1B7B0"/>
 

--- a/assets/xml/objects/object_js.xml
+++ b/assets/xml/objects/object_js.xml
@@ -34,16 +34,16 @@
         <Texture Name="gCarpetMerchantTLUT" OutName="tlut" Format="rgb5a1" Width="16" Height="16" Offset="0x4C20"/>
 
         <!-- Carpet Merchant DisplayList Textures -->
-        <Texture Name="gCarpetMerchantPantsTex" OutName="pants" Format="ci8" Width="8" Height="16" Offset="0x4E20"/>
-        <Texture Name="gCarpetMerchantHairTex" OutName="hair" Format="ci8" Width="16" Height="16" Offset="0x4EA0"/>
-        <Texture Name="gCarpetMerchantFootTex" OutName="foot" Format="ci8" Width="32" Height="16" Offset="0x4FA0"/>
-        <Texture Name="gCarpetMerchantSkinGradientTex" OutName="skin_gradient" Format="ci8" Width="8" Height="8" Offset="0x51A0"/>
-        <Texture Name="gCarpetMerchantFootSoleTex" OutName="foot_sole" Format="ci8" Width="32" Height="32" Offset="0x51E0"/>
-        <Texture Name="gCarpetMerchantHandTex" OutName="hand" Format="ci8" Width="16" Height="16" Offset="0x55E0"/>
-        <Texture Name="gCarpetMerchantBraceletTex" OutName="bracelet" Format="ci8" Width="16" Height="32" Offset="0x56E0"/>
-        <Texture Name="gCarpetMerchantShirtTex" OutName="shirt" Format="ci8" Width="16" Height="32" Offset="0x58E0"/>
-        <Texture Name="gCarpetMerchantChestTex" OutName="chest" Format="ci8" Width="16" Height="32" Offset="0x5AE0"/>
-        <Texture Name="gCarpetMerchantHatTex" OutName="hat" Format="ci8" Width="16" Height="16" Offset="0x5CE0"/>
+        <Texture Name="gCarpetMerchantPantsTex" OutName="pants" Format="ci8" Width="8" Height="16" Offset="0x4E20" TlutOffset="0x4C20"/>
+        <Texture Name="gCarpetMerchantHairTex" OutName="hair" Format="ci8" Width="16" Height="16" Offset="0x4EA0" TlutOffset="0x4C20"/>
+        <Texture Name="gCarpetMerchantFootTex" OutName="foot" Format="ci8" Width="32" Height="16" Offset="0x4FA0" TlutOffset="0x4C20"/>
+        <Texture Name="gCarpetMerchantSkinGradientTex" OutName="skin_gradient" Format="ci8" Width="8" Height="8" Offset="0x51A0" TlutOffset="0x4C20"/>
+        <Texture Name="gCarpetMerchantFootSoleTex" OutName="foot_sole" Format="ci8" Width="32" Height="32" Offset="0x51E0" TlutOffset="0x4C20"/>
+        <Texture Name="gCarpetMerchantHandTex" OutName="hand" Format="ci8" Width="16" Height="16" Offset="0x55E0" TlutOffset="0x4C20"/>
+        <Texture Name="gCarpetMerchantBraceletTex" OutName="bracelet" Format="ci8" Width="16" Height="32" Offset="0x56E0" TlutOffset="0x4C20"/>
+        <Texture Name="gCarpetMerchantShirtTex" OutName="shirt" Format="ci8" Width="16" Height="32" Offset="0x58E0" TlutOffset="0x4C20"/>
+        <Texture Name="gCarpetMerchantChestTex" OutName="chest" Format="ci8" Width="16" Height="32" Offset="0x5AE0" TlutOffset="0x4C20"/>
+        <Texture Name="gCarpetMerchantHatTex" OutName="hat" Format="ci8" Width="16" Height="16" Offset="0x5CE0" TlutOffset="0x4C20"/>
 
         <!-- Carpet Merchant Animations -->
         <Animation Name="gCarpetMerchantSlappingKneeAnim" Offset="0x45C"/>

--- a/assets/xml/objects/object_kibako2.xml
+++ b/assets/xml/objects/object_kibako2.xml
@@ -9,9 +9,9 @@
         <Texture Name="gLargeCrate2TLUT" OutName="tlut_2" Format="rgb5a1" Width="4" Height="4" Offset="0xBA0"/>
 
         <!-- Textures -->
-        <Texture Name="gLargeCrateTex" OutName="crate_tex" Format="ci4" Width="32" Height="64" Offset="0x20"/>
-        <Texture Name="gLargeCrateFragment1Tex" OutName="fragment_1" Format="ci4" Width="32" Height="64" Offset="0x420"/>
-        <Texture Name="gLargeCrateFragment2Tex" OutName="fragment_2" Format="ci4" Width="32" Height="64" Offset="0xBC0"/>
+        <Texture Name="gLargeCrateTex" OutName="crate_tex" Format="ci4" Width="32" Height="64" Offset="0x20" TlutOffset="0x0"/>
+        <Texture Name="gLargeCrateFragment1Tex" OutName="fragment_1" Format="ci4" Width="32" Height="64" Offset="0x420" TlutOffset="0x0"/>
+        <Texture Name="gLargeCrateFragment2Tex" OutName="fragment_2" Format="ci4" Width="32" Height="64" Offset="0xBC0" TlutOffset="0xBA0"/>
 
         <!-- Collision -->
         <Collision Name="gLargeCrateCol" Offset="0xB70"/>

--- a/assets/xml/objects/object_masterkokirihead.xml
+++ b/assets/xml/objects/object_masterkokirihead.xml
@@ -4,11 +4,11 @@
         <Texture Name="gKokiriShopkeeperTLUT" OutName="tlut" Format="rgb5a1" Width="248" Height="1" Offset="0x0"/>
         <Texture Name="gKokiriShopkeeperEyeHalfTex" OutName="eye_half" Format="rgb5a1" Width="32" Height="32" Offset="0x1F0"/>
         <Texture Name="gKokiriShopkeeperEyeOpenTex" OutName="eye_open" Format="rgb5a1" Width="32" Height="32" Offset="0xB30"/>
-        <Texture Name="gKokiriShopkeeperHairTex" OutName="hair" Format="ci8" Width="16" Height="16" Offset="0x1330"/>
-        <Texture Name="gKokiriShopkeeperNoseTex" OutName="nose" Format="ci8" Width="8" Height="8" Offset="0x1430"/>
-        <Texture Name="gKokiriShopkeeperEarTex" OutName="ear" Format="ci8" Width="16" Height="16" Offset="0x1470"/>
+        <Texture Name="gKokiriShopkeeperHairTex" OutName="hair" Format="ci8" Width="16" Height="16" Offset="0x1330" TlutOffset="0x0"/>
+        <Texture Name="gKokiriShopkeeperNoseTex" OutName="nose" Format="ci8" Width="8" Height="8" Offset="0x1430" TlutOffset="0x0"/>
+        <Texture Name="gKokiriShopkeeperEarTex" OutName="ear" Format="ci8" Width="16" Height="16" Offset="0x1470" TlutOffset="0x0"/>
         <Texture Name="gKokiriShopkeeperEyeDefaultTex" OutName="eye_default" Format="rgb5a1" Width="32" Height="32" Offset="0x1570"/>
-        <Texture Name="gKokiriShopkeeperHatTex" OutName="hat" Format="ci8" Width="8" Height="8" Offset="0x1D70"/>
-        <Texture Name="gKokiriShopkeeperMouthAndNoseTex" OutName="mouth_and_nose" Format="ci8" Width="32" Height="32" Offset="0x1DB0"/>
+        <Texture Name="gKokiriShopkeeperHatTex" OutName="hat" Format="ci8" Width="8" Height="8" Offset="0x1D70" TlutOffset="0x0"/>
+        <Texture Name="gKokiriShopkeeperMouthAndNoseTex" OutName="mouth_and_nose" Format="ci8" Width="32" Height="32" Offset="0x1DB0" TlutOffset="0x0"/>
     </File>
 </Root>

--- a/assets/xml/objects/object_md.xml
+++ b/assets/xml/objects/object_md.xml
@@ -44,10 +44,10 @@
         <Texture Name="gMido3TLUT" OutName="tlut_3" Format="rgb5a1" Width="248" Height="1" Offset="0x4DC0"/>
 
         <!-- Mido Eye Textures -->
-        <Texture Name="gMidoEyeOpenTex" OutName="mido_eye_open" Format="ci8" Width="32" Height="32" Offset="0x4FF0"/>
-        <Texture Name="gMidoEyeHalfTex" OutName="mido_eye_half" Format="ci8" Width="32" Height="32" Offset="0x5930"/>
-        <Texture Name="gMidoEyeClosedTex" OutName="mido_eye_closed" Format="ci8" Width="32" Height="32" Offset="0x5D30"/>
-        <Texture Name="gMidoEyeAngryTex" OutName="mido_eye_angry" Format="ci8" Width="32" Height="32" Offset="0x6130"/>
+        <Texture Name="gMidoEyeOpenTex" OutName="mido_eye_open" Format="ci8" Width="32" Height="32" Offset="0x4FF0" TlutOffset="0x4DC0"/>
+        <Texture Name="gMidoEyeHalfTex" OutName="mido_eye_half" Format="ci8" Width="32" Height="32" Offset="0x5930" TlutOffset="0x4DC0"/>
+        <Texture Name="gMidoEyeClosedTex" OutName="mido_eye_closed" Format="ci8" Width="32" Height="32" Offset="0x5D30" TlutOffset="0x4DC0"/>
+        <Texture Name="gMidoEyeAngryTex" OutName="mido_eye_angry" Format="ci8" Width="32" Height="32" Offset="0x6130" TlutOffset="0x4DC0"/>
         <Texture Name="gMidoEyeLookingUpTex" OutName="mido_eye_looking_up" Format="rgb5a1" Width="32" Height="32" Offset="0x520"/>
 
         <!-- Mido DisplayList Textures -->
@@ -55,20 +55,20 @@
         <Texture Name="gMidoTex_D20" OutName="tex_D20" Format="rgb5a1" Width="8" Height="8" Offset="0xD20"/>
         <Texture Name="gMidoTex_DA0" OutName="tex_DA0" Format="ci8" Width="32" Height="4" Offset="0xDA0"/>
         <Texture Name="gMidoHairCurl1Tex" OutName="hair_curl_1" Format="ci8" Width="32" Height="32" Offset="0xE20"/>
-        <Texture Name="gMidoTex_1220" OutName="tex_1220" Format="ci8" Width="8" Height="8" Offset="0x1220"/>
-        <Texture Name="gMidoTex_1260" OutName="tex_1260" Format="ci8" Width="8" Height="8" Offset="0x1260"/>
-        <Texture Name="gMidoBackOfHandTex" OutName="back_of_hand" Format="ci8" Width="8" Height="8" Offset="0x12A0"/>
-        <Texture Name="gMidoClothesTex" OutName="clothes" Format="ci8" Width="8" Height="8" Offset="0x12E0"/>
+        <Texture Name="gMidoTex_1220" OutName="tex_1220" Format="ci8" Width="8" Height="8" Offset="0x1220" TlutOffset="0x02E0"/>
+        <Texture Name="gMidoTex_1260" OutName="tex_1260" Format="ci8" Width="8" Height="8" Offset="0x1260" TlutOffset="0x02E0"/>
+        <Texture Name="gMidoBackOfHandTex" OutName="back_of_hand" Format="ci8" Width="8" Height="8" Offset="0x12A0" TlutOffset="0x02E0"/>
+        <Texture Name="gMidoClothesTex" OutName="clothes" Format="ci8" Width="8" Height="8" Offset="0x12E0" TlutOffset="0x02E0"/>
         <Texture Name="gMidoUndershirtTex" OutName="undershirt" Format="i8" Width="8" Height="8" Offset="0x1320"/>
-        <Texture Name="gMidoShoeTex" OutName="shoe" Format="ci8" Width="8" Height="8" Offset="0x1360"/>
-        <Texture Name="gMidoAnkleTex" OutName="ankle" Format="ci8" Width="8" Height="8" Offset="0x13A0"/>
+        <Texture Name="gMidoShoeTex" OutName="shoe" Format="ci8" Width="8" Height="8" Offset="0x1360" TlutOffset="0x02E0"/>
+        <Texture Name="gMidoAnkleTex" OutName="ankle" Format="ci8" Width="8" Height="8" Offset="0x13A0" TlutOffset="0x02E0"/>
         <Texture Name="gMidoPantsTex" OutName="pants" Format="rgb5a1" Width="16" Height="16" Offset="0x13E0"/>
-        <Texture Name="gMidoTex_4FB0" OutName="tex_4FB0" Format="ci8" Width="8" Height="8" Offset="0x4FB0"/>
-        <Texture Name="gMidoTex_53F0" OutName="tex_53F0" Format="ci8" Width="8" Height="8" Offset="0x53F0"/>
-        <Texture Name="gMidoTex_5430" OutName="tex_5430" Format="ci8" Width="8" Height="8" Offset="0x5430"/>
-        <Texture Name="gMidoHairCurl2Tex" OutName="hair_curl_2" Format="ci8" Width="32" Height="32" Offset="0x5470"/>
-        <Texture Name="gMidoTex_5870" OutName="tex_5870" Format="ci8" Width="8" Height="16" Offset="0x5870"/>
-        <Texture Name="gMidoTex_58F0" OutName="tex_58F0" Format="ci8" Width="8" Height="8" Offset="0x58F0"/>
+        <Texture Name="gMidoTex_4FB0" OutName="tex_4FB0" Format="ci8" Width="8" Height="8" Offset="0x4FB0" TlutOffset="0x4C48"/>
+        <Texture Name="gMidoTex_53F0" OutName="tex_53F0" Format="ci8" Width="8" Height="8" Offset="0x53F0" TlutOffset="0x4C48"/>
+        <Texture Name="gMidoTex_5430" OutName="tex_5430" Format="ci8" Width="8" Height="8" Offset="0x5430" TlutOffset="0x4C48"/>
+        <Texture Name="gMidoHairCurl2Tex" OutName="hair_curl_2" Format="ci8" Width="32" Height="32" Offset="0x5470" TlutOffset="0x4C48"/>
+        <Texture Name="gMidoTex_5870" OutName="tex_5870" Format="ci8" Width="8" Height="16" Offset="0x5870" TlutOffset="0x4C48"/>
+        <Texture Name="gMidoTex_58F0" OutName="tex_58F0" Format="ci8" Width="8" Height="8" Offset="0x58F0" TlutOffset="0x4C48"/>
 
         <!-- Mido Animations -->
         <Animation Name="gMidoHandsOnHipsIdleAnim" Offset="0x02C8"/>

--- a/assets/xml/objects/object_ms.xml
+++ b/assets/xml/objects/object_ms.xml
@@ -26,16 +26,16 @@
         <Texture Name="gBeanSalesmanTLUT" OutName="tlut" Format="rgb5a1" Width="16" Height="16" Offset="0x3230"/>
 
         <!-- Bean Salesman DisplayList Textures -->
-        <Texture Name="gBeanSalesmanBackOfHandTex" OutName="back_of_hand" Format="ci8" Width="16" Height="16" Offset="0x3430"/>
-        <Texture Name="gBeanSalesmanTattooTex" OutName="tattoo" Format="ci8" Width="32" Height="32" Offset="0x3530"/>
-        <Texture Name="gBeanSalesmanMouthTex" OutName="mouth" Format="ci8" Width="16" Height="16" Offset="0x3930"/>
-        <Texture Name="gBeanSalesmanEarTex" OutName="ear" Format="ci8" Width="8" Height="8" Offset="0x3A30"/>
-        <Texture Name="gBeanSalesmanNoseTex" OutName="nose" Format="ci8" Width="8" Height="8" Offset="0x3A70"/>
-        <Texture Name="gBeanSalesmanEyeTex" OutName="eye" Format="ci8" Width="8" Height="8" Offset="0x3AB0"/>
-        <Texture Name="gBeanSalesmanPantsTex" OutName="pants" Format="ci8" Width="16" Height="16" Offset="0x3AF0"/>
-        <Texture Name="gBeanSalesmanShoeTex" OutName="shoe" Format="ci8" Width="8" Height="8" Offset="0x3BF0"/>
-        <Texture Name="gBeanSalesmanSkinGradientTex" OutName="skin_gradient" Format="ci8" Width="4" Height="4" Offset="0x3C30"/>
-        <Texture Name="gBeanSalesmanBeanbagTex" OutName="beanbag" Format="ci8" Width="16" Height="16" Offset="0x3C40"/>
+        <Texture Name="gBeanSalesmanBackOfHandTex" OutName="back_of_hand" Format="ci8" Width="16" Height="16" Offset="0x3430" TlutOffset="0x3230"/>
+        <Texture Name="gBeanSalesmanTattooTex" OutName="tattoo" Format="ci8" Width="32" Height="32" Offset="0x3530" TlutOffset="0x3230"/>
+        <Texture Name="gBeanSalesmanMouthTex" OutName="mouth" Format="ci8" Width="16" Height="16" Offset="0x3930" TlutOffset="0x3230"/>
+        <Texture Name="gBeanSalesmanEarTex" OutName="ear" Format="ci8" Width="8" Height="8" Offset="0x3A30" TlutOffset="0x3230"/>
+        <Texture Name="gBeanSalesmanNoseTex" OutName="nose" Format="ci8" Width="8" Height="8" Offset="0x3A70" TlutOffset="0x3230"/>
+        <Texture Name="gBeanSalesmanEyeTex" OutName="eye" Format="ci8" Width="8" Height="8" Offset="0x3AB0" TlutOffset="0x3230"/>
+        <Texture Name="gBeanSalesmanPantsTex" OutName="pants" Format="ci8" Width="16" Height="16" Offset="0x3AF0" TlutOffset="0x3230"/>
+        <Texture Name="gBeanSalesmanShoeTex" OutName="shoe" Format="ci8" Width="8" Height="8" Offset="0x3BF0" TlutOffset="0x3230"/>
+        <Texture Name="gBeanSalesmanSkinGradientTex" OutName="skin_gradient" Format="ci8" Width="4" Height="4" Offset="0x3C30" TlutOffset="0x3230"/>
+        <Texture Name="gBeanSalesmanBeanbagTex" OutName="beanbag" Format="ci8" Width="16" Height="16" Offset="0x3C40" TlutOffset="0x3230"/>
 
         <!-- Bean Salesman Animations -->
         <Animation Name="gBeanSalesmanEatingAnim" Offset="0x5EC"/>

--- a/assets/xml/objects/object_relay_objects.xml
+++ b/assets/xml/objects/object_relay_objects.xml
@@ -8,7 +8,7 @@
         <Texture Name="gWindmillRotatingPlatformTLUT" OutName="windmill_platform_tlut" Format="rgb5a1" Width="4" Height="4" Offset="0x3F0"/>
 
         <!-- Textures -->
-        <Texture Name="gWindmillRotatingPlatform1Tex" OutName="windmill_platform_1" Format="ci4" Width="64" Height="64" Offset="0x410"/>
+        <Texture Name="gWindmillRotatingPlatform1Tex" OutName="windmill_platform_1" Format="ci4" Width="64" Height="64" Offset="0x410" TlutOffset="0x3F0"/>
         <Texture Name="gWindmillRotatingPlatform2Tex" OutName="windmill_platform_2" Format="rgb5a1" Width="32" Height="16" Offset="0xC10"/>
         <Texture Name="gDampeRaceDoorTex" OutName="dampe_race_door" Format="i4" Width="64" Height="128" Offset="0x2630"/>
 

--- a/assets/xml/objects/object_ru2.xml
+++ b/assets/xml/objects/object_ru2.xml
@@ -60,23 +60,23 @@
         <Texture Name="gAdultRutoEyeClosedTex" OutName="adult_ruto_eye_closed" Format="rgb5a1" Width="32" Height="32" Offset="0x2AE0"/>
         
         <!-- Adult Ruto Textures -->
-        <Texture Name="gAdultRutoSkinGradient" OutName="adult_ruto_skin_gradient" Format="ci8" Width="8" Height="8" Offset="0x1720"/>
-        <Texture Name="gAdultRutoEar1Tex" OutName="adult_ruto_ear_1" Format="ci8" Width="16" Height="16" Offset="0x1760"/>
-        <Texture Name="gAdultRutoHeadGradientTex" OutName="adult_ruto_head_gradient" Format="ci8" Width="16" Height="16" Offset="0x1860"/>
-        <Texture Name="gAdultRutoHeadHoleTex" OutName="adult_ruto_head_hole" Format="ci8" Width="8" Height="8" Offset="0x1960"/>
+        <Texture Name="gAdultRutoSkinGradient" OutName="adult_ruto_skin_gradient" Format="ci8" Width="8" Height="8" Offset="0x1720" TlutOffset="0xE00"/>
+        <Texture Name="gAdultRutoEar1Tex" OutName="adult_ruto_ear_1" Format="ci8" Width="16" Height="16" Offset="0x1760" TlutOffset="0xE00"/>
+        <Texture Name="gAdultRutoHeadGradientTex" OutName="adult_ruto_head_gradient" Format="ci8" Width="16" Height="16" Offset="0x1860" TlutOffset="0xE00"/>
+        <Texture Name="gAdultRutoHeadHoleTex" OutName="adult_ruto_head_hole" Format="ci8" Width="8" Height="8" Offset="0x1960" TlutOffset="0xE00"/>
         <Texture Name="gAdultRutoMouthTex" OutName="adult_ruto_mouth" Format="rgb5a1" Width="32" Height="32" Offset="0x19A0"/>
-        <Texture Name="gAdultRutoTex_21A0" OutName="adult_ruto_tex_21A0" Format="ci8" Width="8" Height="8" Offset="0x21A0"/>
-        <Texture Name="gAdultRutoEar2Tex" OutName="adult_ruto_ear_2" Format="ci8" Width="16" Height="16" Offset="0x21E0"/>
+        <Texture Name="gAdultRutoTex_21A0" OutName="adult_ruto_tex_21A0" Format="ci8" Width="8" Height="8" Offset="0x21A0" TlutOffset="0xE00"/>
+        <Texture Name="gAdultRutoEar2Tex" OutName="adult_ruto_ear_2" Format="ci8" Width="16" Height="16" Offset="0x21E0" TlutOffset="0xE00"/>
         <Texture Name="gAdultRutoEarringTex" OutName="adult_ruto_earring" Format="rgb5a1" Width="8" Height="16" Offset="0x32E0"/>
-        <Texture Name="gAdultRutoTailGradientTex" OutName="adult_ruto_tail_gradient" Format="ci8" Width="8" Height="8" Offset="0x45C0"/>
-        <Texture Name="gAdultRutoTex_4600" OutName="adult_ruto_tex_4600" Format="ci8" Width="8" Height="8" Offset="0x4600"/>
-        <Texture Name="gAdultRutoBackOfHandTex" OutName="adult_ruto_back_of_hand" Format="ci8" Width="16" Height="16" Offset="0x4640"/>
-        <Texture Name="gAdultRutoTex_4740" OutName="adult_ruto_tex_4740" Format="ci8" Width="16" Height="16" Offset="0x4740"/>
-        <Texture Name="gAdultRutoSkinPattern1Tex" OutName="adult_ruto_skin_pattern_1" Format="ci8" Width="32" Height="64" Offset="0x4840"/>
-        <Texture Name="gAdultRutoSkinPattern2Tex" OutName="adult_ruto_skin_pattern_2" Format="ci8" Width="32" Height="32" Offset="0x5040"/>
-        <Texture Name="gAdultRutoTex_5440" OutName="adult_ruto_tex_5440" Format="ci8" Width="8" Height="8" Offset="0x5440"/>
-        <Texture Name="gAdultRutoTex_5480" OutName="adult_ruto_tex_5480" Format="ci8" Width="16" Height="16" Offset="0x5480"/>
-        <Texture Name="gAdultRutoTex_5580" OutName="adult_ruto_tex_5580" Format="ci8" Width="8" Height="8" Offset="0x5580"/>
+        <Texture Name="gAdultRutoTailGradientTex" OutName="adult_ruto_tail_gradient" Format="ci8" Width="8" Height="8" Offset="0x45C0" TlutOffset="0x43C0"/>
+        <Texture Name="gAdultRutoTex_4600" OutName="adult_ruto_tex_4600" Format="ci8" Width="8" Height="8" Offset="0x4600" TlutOffset="0x43C0"/>
+        <Texture Name="gAdultRutoBackOfHandTex" OutName="adult_ruto_back_of_hand" Format="ci8" Width="16" Height="16" Offset="0x4640" TlutOffset="0x43C0"/>
+        <Texture Name="gAdultRutoTex_4740" OutName="adult_ruto_tex_4740" Format="ci8" Width="16" Height="16" Offset="0x4740" TlutOffset="0x43C0"/>
+        <Texture Name="gAdultRutoSkinPattern1Tex" OutName="adult_ruto_skin_pattern_1" Format="ci8" Width="32" Height="64" Offset="0x4840" TlutOffset="0x43C0"/>
+        <Texture Name="gAdultRutoSkinPattern2Tex" OutName="adult_ruto_skin_pattern_2" Format="ci8" Width="32" Height="32" Offset="0x5040" TlutOffset="0x43C0"/>
+        <Texture Name="gAdultRutoTex_5440" OutName="adult_ruto_tex_5440" Format="ci8" Width="8" Height="8" Offset="0x5440" TlutOffset="0x43C0"/>
+        <Texture Name="gAdultRutoTex_5480" OutName="adult_ruto_tex_5480" Format="ci8" Width="16" Height="16" Offset="0x5480" TlutOffset="0x43C0"/>
+        <Texture Name="gAdultRutoTex_5580" OutName="adult_ruto_tex_5580" Format="ci8" Width="8" Height="8" Offset="0x5580" TlutOffset="0x43C0"/>
 
         <!-- Adult Ruto Animations -->
         <Animation Name="gAdultRutoCrossingArmsAnim" Offset="0x04CC"/>

--- a/assets/xml/objects/object_spot01_matoya.xml
+++ b/assets/xml/objects/object_spot01_matoya.xml
@@ -3,10 +3,10 @@
         <!-- Kakariko Shooting Gallery -->
         <DList Name="gKakarikoShootingGalleryDL" Offset="0x1528"/>
         <DList Name="gKakarikoShootingGallerySignDL" Offset="0x2780"/>
-        <Texture Name="gKakarikoShootingGalleryRoofEdgeTex" OutName="shooting_gallery_roof_edge" Format="ci8" Width="32" Height="32" Offset="0x208"/>
-        <Texture Name="gKakarikoShootingGalleryRoofTex" OutName="shooting_gallery_roof" Format="ci8" Width="16" Height="32" Offset="0x608"/>
-        <Texture Name="gKakarikoShootingGalleryDoorShadowTex" OutName="shooting_gallery_door_shadow" Format="ci8" Width="16" Height="32" Offset="0x808"/>
-        <Texture Name="gKakarikoShootingGalleryWallTex" OutName="shooting_gallery_wall" Format="ci8" Width="32" Height="64" Offset="0xA08"/>
+        <Texture Name="gKakarikoShootingGalleryRoofEdgeTex" OutName="shooting_gallery_roof_edge" Format="ci8" Width="32" Height="32" Offset="0x208" TlutOffset="0x0"/>
+        <Texture Name="gKakarikoShootingGalleryRoofTex" OutName="shooting_gallery_roof" Format="ci8" Width="16" Height="32" Offset="0x608" TlutOffset="0x0"/>
+        <Texture Name="gKakarikoShootingGalleryDoorShadowTex" OutName="shooting_gallery_door_shadow" Format="ci8" Width="16" Height="32" Offset="0x808" TlutOffset="0x0"/>
+        <Texture Name="gKakarikoShootingGalleryWallTex" OutName="shooting_gallery_wall" Format="ci8" Width="32" Height="64" Offset="0xA08" TlutOffset="0x0"/>
         <Texture Name="gKakarikoShootingGallerySignTex" OutName="shooting_gallery_sign" Format="rgb5a1" Width="32" Height="32" Offset="0x1F40"/>
         <Collision Name="gKakarikoShootingGalleryCol" Offset="0x1A38"/>
 
@@ -16,7 +16,7 @@
 
         <!-- Kakariko Bazaar -->
         <DList Name="gKakarikoBazaarSignDL" Offset="0x3078"/>
-        <Texture Name="gKakarikoBazaarSignTex" OutName="bazaar_sign" Format="ci4" Width="64" Height="64" Offset="0x2838"/>
+        <Texture Name="gKakarikoBazaarSignTex" OutName="bazaar_sign" Format="ci4" Width="64" Height="64" Offset="0x2838" TlutOffset="0x2810"/>
 
         <!-- BOTW Stone -->
         <DList Name="gKakarikoBOTWStoneDL" Offset="0x3B20"/>

--- a/assets/xml/objects/object_spot01_matoyab.xml
+++ b/assets/xml/objects/object_spot01_matoyab.xml
@@ -8,9 +8,9 @@
         <!-- Kakariko Construction Site -->
         <DList Name="gKakarikoConstructionSiteDL" Offset="0x1228"/>
         <Texture Name="gKakarikoConstructionSiteTLUT" OutName="construction_site_tlut" Format="rgb5a1" Width="16" Height="16" Offset="0x0"/>
-        <Texture Name="gKakarikoConstructionSiteBrickWithGrassTex" OutName="construction_site_brick_with_grass" Format="ci8" Width="16" Height="32" Offset="0x0208"/>
-        <Texture Name="gKakarikoConstructionSiteBrickTex" OutName="construction_site_brick" Format="ci8" Width="16" Height="32" Offset="0x0408"/>
-        <Texture Name="gKakarikoConstructionSitRailingTex" OutName="construction_site_railing" Format="ci8" Width="16" Height="8" Offset="0x0608"/>
-        <Texture Name="gKakarikoConstructionSiteWoodTex" OutName="construction_site_wood" Format="ci8" Width="16" Height="32" Offset="0x0688"/>
+        <Texture Name="gKakarikoConstructionSiteBrickWithGrassTex" OutName="construction_site_brick_with_grass" Format="ci8" Width="16" Height="32" Offset="0x0208" TlutOffset="0x0"/>
+        <Texture Name="gKakarikoConstructionSiteBrickTex" OutName="construction_site_brick" Format="ci8" Width="16" Height="32" Offset="0x0408" TlutOffset="0x0"/>
+        <Texture Name="gKakarikoConstructionSitRailingTex" OutName="construction_site_railing" Format="ci8" Width="16" Height="8" Offset="0x0608" TlutOffset="0x0"/>
+        <Texture Name="gKakarikoConstructionSiteWoodTex" OutName="construction_site_wood" Format="ci8" Width="16" Height="32" Offset="0x0688" TlutOffset="0x0"/>
     </File>
 </Root>

--- a/assets/xml/objects/object_spot08_obj.xml
+++ b/assets/xml/objects/object_spot08_obj.xml
@@ -3,7 +3,7 @@
         <!-- Zora's Fountain Ice Ramp -->
         <DList Name="gZorasFountainIceRampDL" Offset="0xDE0"/>
         <Texture Name="gZorasFountainIceRampTLUT" OutName="ice_ramp_tlut" Format="rgb5a1" Width="4" Height="4" Offset="0x0"/>
-        <Texture Name="gZorasFountainIceRampLowerSideTex" OutName="ice_ramp_lower_side" Format="ci4" Width="64" Height="64" Offset="0x20"/>
+        <Texture Name="gZorasFountainIceRampLowerSideTex" OutName="ice_ramp_lower_side" Format="ci4" Width="64" Height="64" Offset="0x20" TlutOffset="0x0"/>
         <Texture Name="gZorasFountainIceRampSurfaceTex" OutName="ice_ramp_surface" Format="rgb5a1" Width="32" Height="32" Offset="0x3E00"/>
         <Texture Name="gZorasFountainIceRampUpperSideTex" OutName="ice_ramp_upper_side" Format="rgb5a1" Width="32" Height="32" Offset="0x4600"/>
         <Texture Name="gZorasFountainIceRampMiddleSlopeTex" OutName="ice_ramp_middle_slope" Format="rgb5a1" Width="32" Height="32" Offset="0x4E00"/>
@@ -13,15 +13,15 @@
         <DList Name="gZorasFountainIcebergDL" Offset="0x2BD0"/>
         <Texture Name="gZorasFountainIceberg1TLUT" OutName="iceberg_tlut_1" Format="rgb5a1" Width="4" Height="4" Offset="0x1930"/>
         <Texture Name="gZorasFountainIceberg2TLUT" OutName="iceberg_tlut_2" Format="rgb5a1" Width="4" Height="4" Offset="0x1950"/>
-        <Texture Name="gZorasFountainIcebergSideTex" OutName="iceberg_side" Format="ci4" Width="64" Height="64" Offset="0x1970"/>
-        <Texture Name="gZorasFountainIcebergTopTex" OutName="iceberg_top" Format="ci4" Width="64" Height="64" Offset="0x2170"/>
+        <Texture Name="gZorasFountainIcebergSideTex" OutName="iceberg_side" Format="ci4" Width="64" Height="64" Offset="0x1970" TlutOffset="0x1930"/>
+        <Texture Name="gZorasFountainIcebergTopTex" OutName="iceberg_top" Format="ci4" Width="64" Height="64" Offset="0x2170" TlutOffset="0x1950"/>
         <Texture Name="gZorasFountainIcebergUndersideTex" OutName="iceberg_underside" Format="rgb5a1" Width="64" Height="8" Offset="0x3A00"/> 
         <Collision Name="gZorasFountainIcebergCol" Offset="0x2FD8"/>
 
         <!-- Zora's Fountain Bombable Wall -->
         <DList Name="gZorasFountainBombableWallDL" Offset="0x3898"/>
         <Texture Name="gZorasFountainBombableWallTLUT" OutName="bombable_wall_tlut" Format="rgb5a1" Width="4" Height="4" Offset="0x3010"/>
-        <Texture Name="gZorasFountainBombableWallTex" OutName="bombable_wall" Format="ci4" Width="128" Height="32" Offset="0x3038"/>
+        <Texture Name="gZorasFountainBombableWallTex" OutName="bombable_wall" Format="ci4" Width="128" Height="32" Offset="0x3038" TlutOffset="0x3010"/>
         <Collision Name="gZorasFountainBombableWallCol" Offset="0x39D4"/> 
     </File>
 </Root>

--- a/assets/xml/objects/object_spot18_obj.xml
+++ b/assets/xml/objects/object_spot18_obj.xml
@@ -11,8 +11,8 @@
         <Texture Name="gGoronCityVaseTLUT" OutName="vase_tlut" Format="rgb5a1" Width="4" Height="4" Offset="0x560"/>
 
         <!-- Textures -->
-        <Texture Name="gGoronCityVaseTex_580" OutName="vase_580" Format="ci4" Width="64" Height="64" Offset="0x580"/>
-        <Texture Name="gGoronCityVaseTex_D80" OutName="vase_D80" Format="ci4" Width="32" Height="32" Offset="0xD80"/>
+        <Texture Name="gGoronCityVaseTex_580" OutName="vase_580" Format="ci4" Width="64" Height="64" Offset="0x580" TlutOffset="0x560"/>
+        <Texture Name="gGoronCityVaseTex_D80" OutName="vase_D80" Format="ci4" Width="32" Height="32" Offset="0xD80" TlutOffset="0x560"/>
         <Texture Name="gGoronCitySpearLeafTex" OutName="spear_leaf" Format="rgb5a1" Width="32" Height="64" Offset="0x3010"/>
         <Texture Name="gGoronCitySpearTipTex" OutName="spear_tip" Format="rgb5a1" Width="32" Height="32" Offset="0x4010"/>
         <Texture Name="gGoronCitySpearHandleTex" OutName="spear_handle" Format="rgb5a1" Width="32" Height="32" Offset="0x4810"/>

--- a/assets/xml/objects/object_zl1.xml
+++ b/assets/xml/objects/object_zl1.xml
@@ -41,36 +41,36 @@
         <DList Name="gChildZelda1HeadDL" Offset="0xCD98"/>
 
         <!-- Textures -->
-        <Texture Name="gChildZelda1DressGradientTex" OutName="dress_gradient" Format="ci8" Width="8" Height="8" Offset="0x0650"/>
-        <Texture Name="gChildZelda1PurpleDressPatternTex" OutName="purple_dress_pattern" Format="ci8" Width="16" Height="16" Offset="0x0690"/>
-        <Texture Name="gChildZelda1TriforceSashTex" OutName="triforce_sash" Format="ci8" Width="32" Height="64" Offset="0x0790"/>
-        <Texture Name="gChildZelda1BeltTex" OutName="belt" Format="ci8" Width="32" Height="8" Offset="0x0F90"/>
-        <Texture Name="gChildZelda1BeltLoopsTex" OutName="belt_loops" Format="ci8" Width="8" Height="8" Offset="0x1090"/>
-        <Texture Name="gChildZelda1DressWrinklesTex" OutName="dress_wrinkles" Format="ci8" Width="32" Height="32" Offset="0x10D0"/>
+        <Texture Name="gChildZelda1DressGradientTex" OutName="dress_gradient" Format="ci8" Width="8" Height="8" Offset="0x0650" TlutOffset="0x0450"/>
+        <Texture Name="gChildZelda1PurpleDressPatternTex" OutName="purple_dress_pattern" Format="ci8" Width="16" Height="16" Offset="0x0690" TlutOffset="0x0450"/>
+        <Texture Name="gChildZelda1TriforceSashTex" OutName="triforce_sash" Format="ci8" Width="32" Height="64" Offset="0x0790" TlutOffset="0x0450"/>
+        <Texture Name="gChildZelda1BeltTex" OutName="belt" Format="ci8" Width="32" Height="8" Offset="0x0F90" TlutOffset="0x0450"/>
+        <Texture Name="gChildZelda1BeltLoopsTex" OutName="belt_loops" Format="ci8" Width="8" Height="8" Offset="0x1090" TlutOffset="0x0450"/>
+        <Texture Name="gChildZelda1DressWrinklesTex" OutName="dress_wrinkles" Format="ci8" Width="32" Height="32" Offset="0x10D0" TlutOffset="0x0450"/>
         <Texture Name="gChildZelda1BackOfHandTex" OutName="back_of_hand" Format="rgb5a1" Width="16" Height="16" Offset="0x14D0"/>
-        <Texture Name="gChildZelda1BraceletTex" OutName="bracelet" Format="ci8" Width="16" Height="16" Offset="0x16D0"/>
+        <Texture Name="gChildZelda1BraceletTex" OutName="bracelet" Format="ci8" Width="16" Height="16" Offset="0x16D0" TlutOffset="0x0450"/>
         <Texture Name="gChildZelda1BlueUndershirtGradient1Tex" OutName="blue_undershirt_gradient_1" Format="rgb5a1" Width="8" Height="8" Offset="0x17D0"/>
         <Texture Name="gChildZelda1BlueUndershirtGradient2Tex" OutName="blue_undershirt_gradient_2" Format="rgb5a1" Width="16" Height="16" Offset="0x1850"/>
-        <Texture Name="gChildZelda1Tex_1A50" OutName="tex_1A50" Format="ci8" Width="8" Height="8" Offset="0x1A50"/>
-        <Texture Name="gChildZelda1StripedShoulderPatternTex" OutName="striped_shoulder_pattern" Format="ci8" Width="8" Height="8" Offset="0x1A90"/>
-        <Texture Name="gChildZelda1UndershirtWrinklesTex" OutName="undershirt_wrinkles" Format="ci8" Width="16" Height="16" Offset="0x1AD0"/>
+        <Texture Name="gChildZelda1Tex_1A50" OutName="tex_1A50" Format="ci8" Width="8" Height="8" Offset="0x1A50" TlutOffset="0x0450"/>
+        <Texture Name="gChildZelda1StripedShoulderPatternTex" OutName="striped_shoulder_pattern" Format="ci8" Width="8" Height="8" Offset="0x1A90" TlutOffset="0x0450"/>
+        <Texture Name="gChildZelda1UndershirtWrinklesTex" OutName="undershirt_wrinkles" Format="ci8" Width="16" Height="16" Offset="0x1AD0" TlutOffset="0x0450"/>
         <Texture Name="gChildZelda1PendantTex" OutName="pendant" Format="rgb5a1" Width="32" Height="32" Offset="0x1BD0"/>
-        <Texture Name="gChildZelda1HeaddressGradientTex" OutName="headdress_gradient" Format="ci8" Width="8" Height="8" Offset="0x7A08"/>
+        <Texture Name="gChildZelda1HeaddressGradientTex" OutName="headdress_gradient" Format="ci8" Width="8" Height="8" Offset="0x7A08" TlutOffset="0x70C8"/>
         <Texture Name="gChildZelda1SkinGradientTex" OutName="skin_gradient" Format="rgb5a1" Width="8" Height="8" Offset="0x7A48"/>
         <Texture Name="gChildZelda1HeaddressTriforceEmblemTex" OutName="headdress_triforce_emblem" Format="rgb5a1" Width="16" Height="32" Offset="0x7AC8"/>
         <Texture Name="gChildZelda1PointedHairOnSideTex" OutName="pointed_hair_on_side" Format="rgb5a1" Width="16" Height="16" Offset="0x7EC8"/>
         <Texture Name="gChildZelda1HairTex" OutName="hair" Format="rgb5a1" Width="16" Height="8" Offset="0x80C8"/>
-        <Texture Name="gChildZelda1Tex_81C8" OutName="tex_81C8" Format="ci8" Width="8" Height="8" Offset="0x81C8"/>
+        <Texture Name="gChildZelda1Tex_81C8" OutName="tex_81C8" Format="ci8" Width="8" Height="8" Offset="0x81C8" TlutOffset="0x70C8"/>
         <Texture Name="gChildZelda1EarTex" OutName="ear" Format="rgb5a1" Width="16" Height="16" Offset="0x8208"/>
-        <Texture Name="gChildZelda1AlternateDressPatternTex" OutName="alternate_dress_pattern" Format="ci8" Width="8" Height="8" Offset="0x8408"/>
-        <Texture Name="gChildZelda1ALternateDressBeltTex" OutName="alternate_dress_belt" Format="ci8" Width="32" Height="8" Offset="0x8448"/>
-        <Texture Name="gChildZelda1AlternateDressGradientTex" OutName="alternate_dress_gradient" Format="ci8" Width="16" Height="16" Offset="0x8548"/>
+        <Texture Name="gChildZelda1AlternateDressPatternTex" OutName="alternate_dress_pattern" Format="ci8" Width="8" Height="8" Offset="0x8408" TlutOffset="0x70C8"/>
+        <Texture Name="gChildZelda1ALternateDressBeltTex" OutName="alternate_dress_belt" Format="ci8" Width="32" Height="8" Offset="0x8448" TlutOffset="0x70C8"/>
+        <Texture Name="gChildZelda1AlternateDressGradientTex" OutName="alternate_dress_gradient" Format="ci8" Width="16" Height="16" Offset="0x8548" TlutOffset="0x70C8"/>
         <Texture Name="gChildZelda1AlternateDressLiningTex" OutName="alternate_dress_lining" Format="rgb5a1" Width="8" Height="16" Offset="0x8648"/>
         <Texture Name="gChildZelda1BootTex" OutName="boot" Format="rgb5a1" Width="8" Height="8" Offset="0x8748"/>
         <Texture Name="gChildZelda1BootShaftTex" OutName="boot_shaft" Format="rgb5a1" Width="8" Height="8" Offset="0x87C8"/>
         <Texture Name="gChildZelda1Tex_A848" OutName="tex_A848" Format="rgb5a1" Width="8" Height="8" Offset="0xA848"/>
-        <Texture Name="gChildZelda1HeaddressTex_A8C8" OutName="headdress_A8C8" Format="ci8" Width="8" Height="16" Offset="0xA8C8"/>
-        <Texture Name="gChildZelda1HeaddressStripeTex" OutName="headdress_stripe" Format="ci8" Width="16" Height="32" Offset="0xA948"/>
+        <Texture Name="gChildZelda1HeaddressTex_A8C8" OutName="headdress_A8C8" Format="ci8" Width="8" Height="16" Offset="0xA8C8" TlutOffset="0x70C8"/>
+        <Texture Name="gChildZelda1HeaddressStripeTex" OutName="headdress_stripe" Format="ci8" Width="16" Height="32" Offset="0xA948" TlutOffset="0x70C8"/>
 
         <!-- Other DisplayLists -->
         <DList Name="gChildZelda1AlternateDressDL" Offset="0xDEC8"/>
@@ -83,19 +83,19 @@
         <Texture Name="gChildZelda1TLUT_70C8" OutName="tlut_70C8" Format="rgb5a1" Width="160" Height="1" Offset="0x70C8"/>
 
         <!-- Eye Textures -->
-        <Texture Name="gChildZelda1EyeOpenLookingUpRightTex" OutName="eye_open_looking_up_right" Format="ci8" Width="32" Height="32" Offset="0x7208"/>
-        <Texture Name="gChildZelda1EyeOpenLookingLeftTex" OutName="eye_open_looking_left" Format="ci8" Width="32" Height="32" Offset="0x8848"/>
-        <Texture Name="gChildZelda1EyeOpenLookingRightTex" OutName="eye_open_looking_right" Format="ci8" Width="32" Height="32" Offset="0x8C48"/>
-        <Texture Name="gChildZelda1EyeHalf1Tex" OutName="eye_half_1" Format="ci8" Width="32" Height="32" Offset="0x9448"/>
-        <Texture Name="gChildZelda1EyeHalf2Tex" OutName="eye_half_2" Format="ci8" Width="32" Height="32" Offset="0x9848"/>
-        <Texture Name="gChildZelda1EyeClosedTex" OutName="eye_closed" Format="ci8" Width="32" Height="32" Offset="0x9C48"/>
-        <Texture Name="gChildZelda1EyeWideTex" OutName="eye_wide" Format="ci8" Width="32" Height="32" Offset="0xA048"/>
+        <Texture Name="gChildZelda1EyeOpenLookingUpRightTex" OutName="eye_open_looking_up_right" Format="ci8" Width="32" Height="32" Offset="0x7208" TlutOffset="0x6CD8"/>
+        <Texture Name="gChildZelda1EyeOpenLookingLeftTex" OutName="eye_open_looking_left" Format="ci8" Width="32" Height="32" Offset="0x8848" TlutOffset="0x6CD8"/>
+        <Texture Name="gChildZelda1EyeOpenLookingRightTex" OutName="eye_open_looking_right" Format="ci8" Width="32" Height="32" Offset="0x8C48" TlutOffset="0x6CD8"/>
+        <Texture Name="gChildZelda1EyeHalf1Tex" OutName="eye_half_1" Format="ci8" Width="32" Height="32" Offset="0x9448" TlutOffset="0x6CD8"/>
+        <Texture Name="gChildZelda1EyeHalf2Tex" OutName="eye_half_2" Format="ci8" Width="32" Height="32" Offset="0x9848" TlutOffset="0x6CD8"/>
+        <Texture Name="gChildZelda1EyeClosedTex" OutName="eye_closed" Format="ci8" Width="32" Height="32" Offset="0x9C48" TlutOffset="0x6CD8"/>
+        <Texture Name="gChildZelda1EyeWideTex" OutName="eye_wide" Format="ci8" Width="32" Height="32" Offset="0xA048" TlutOffset="0x6CD8"/>
 
         <!-- Mouth Textures -->
-        <Texture Name="gChildZelda1MouthNeutralTex" OutName="mouth_neutral" Format="ci8" Width="32" Height="32" Offset="0x7608"/>
-        <Texture Name="gChildZelda1MouthFrowningTex" OutName="mouth_frowning" Format="ci8" Width="32" Height="32" Offset="0x9048"/>
-        <Texture Name="gChildZelda1MouthOpenTex" OutName="mouth_open" Format="ci8" Width="32" Height="32" Offset="0xA448"/>
-        <Texture Name="gChildZelda1MouthOpenSmilingTex" OutName="mouth_open_smiling" Format="ci8" Width="32" Height="32" Offset="0xAB48"/>
+        <Texture Name="gChildZelda1MouthNeutralTex" OutName="mouth_neutral" Format="ci8" Width="32" Height="32" Offset="0x7608" TlutOffset="0x6ED0"/>
+        <Texture Name="gChildZelda1MouthFrowningTex" OutName="mouth_frowning" Format="ci8" Width="32" Height="32" Offset="0x9048" TlutOffset="0x6ED0"/>
+        <Texture Name="gChildZelda1MouthOpenTex" OutName="mouth_open" Format="ci8" Width="32" Height="32" Offset="0xA448" TlutOffset="0x6ED0"/>
+        <Texture Name="gChildZelda1MouthOpenSmilingTex" OutName="mouth_open_smiling" Format="ci8" Width="32" Height="32" Offset="0xAB48" TlutOffset="0x6ED0"/>
         
         <!-- Animations -->
         <Animation Name="gChildZelda1Anim_00438" Offset="0x00438"/>


### PR DESCRIPTION
This script did most of the work:

<details>

```py
# typical objects/ xml
"""
<Root>
    <File Name="object_ane" Segment="6">
        <Texture Name="gCuccoLadyTLUT" OutName="tlut" Format="rgb5a1" Width="16" Height="16" Offset="0x0108"/>
        <Texture Name="gCuccoLadyHairTex" OutName="hair" Format="ci8" Width="8" Height="16" Offset="0x0308" TlutOffset="0x0108"/>
        <Texture Name="gCuccoLadyTex_0388" OutName="tex_0388" Format="ci8" Width="8" Height="8" Offset="0x0388"/>
        <Texture Name="gCuccoLadyEyeClosedTex" OutName="cucco_lady_eye_closed" Format="rgb5a1" Width="32" Height="32" Offset="0x18C8"/>
    </File>
</Root>
"""

# typical overlays/ xml
"""
<Root>
    <File Name="ovl_Boss_Dodongo" BaseAddress="0x808C1190" RangeStart="0x6238" RangeEnd="0x9238" Segment="128">
        <Texture Name="sLavaFloorLavaTex" OutName="lava_floor_lava" Format="rgb5a1" Width="64" Height="64" Offset="0x6238"/>
        <Texture Name="sLavaFloorRockTex" OutName="lava_floor_rock" Format="rgb5a1" Width="32" Height="64" Offset="0x8238"/>
    </File>
</Root>
"""

# typical scenes/ xml
"""
<Root>
    <File Name="kokiri_shop_scene" Segment="2">
        <Scene Name="kokiri_shop_scene" Offset="0x0"/>
    </File>
    <File Name="kokiri_shop_room_0" Segment="3">
        <Room Name="kokiri_shop_room_0" Offset="0x0"/>
    </File>
</Root>
"""

# typical textures/ xml
"""
<Root>
     <File Name="do_action_static" Segment="7">
        <Texture Name="gAttackDoActionENGTex" OutName="attack_eng" Format="ia4" Width="48" Height="16" Offset="0x0"/>
     </File>
</Root>
"""

import sys
import os
import re

def fail(*msg):
    print(*msg)
    sys.exit(1)

def getTlutUsedNear(file_path, contents, texture_name, texture_format, idx_texture_name):
    idx_before_gsDPLoadTLUT = contents.rfind('gsDPLoadTLUT_pal' + ('16' if texture_format.lower() == 'ci4' else '256'), 0, idx_texture_name)
    idx_after_gsDPLoadTLUT = contents.find('gsDPLoadTLUT_pal' + ('16' if texture_format.lower() == 'ci4' else '256'), idx_texture_name)
    if idx_before_gsDPLoadTLUT < 0 and idx_after_gsDPLoadTLUT < 0:
        fail('Cannot find gsDPLoadTLUT_pal* before nor after', texture_name, 'in', file_path, 'context:', contents[idx_texture_name-50:idx_texture_name+50])
    # ignore a gsDPLoadTLUT_pal*() command that is after a triangle draw command since texture load
    if not idx_after_gsDPLoadTLUT < 0 and any(
        tri_draw_cmd in contents[idx_texture_name:idx_after_gsDPLoadTLUT] for tri_draw_cmd in ('gsSP1Triangle','gsSP2Triangles')
    ):
        idx_after_gsDPLoadTLUT = -1
    # ignore a gsDPLoadTLUT_pal*() command that comes before a triangle draw command before texture load,
    # if there is a gsDPLoadTLUT_pal*() after texture load that isn't separated from texture load by triangle drawing
    if not idx_after_gsDPLoadTLUT < 0 and not idx_before_gsDPLoadTLUT < 0 and any(
        tri_draw_cmd in contents[idx_before_gsDPLoadTLUT:idx_texture_name] for tri_draw_cmd in ('gsSP1Triangle','gsSP2Triangles')
    ):
        idx_before_gsDPLoadTLUT = -1
    if idx_before_gsDPLoadTLUT < 0 and idx_after_gsDPLoadTLUT < 0:
        fail('Cannot find gsDPLoadTLUT_pal* without triangle draw command in-between before nor after', texture_name, 'in', file_path, 'context:', contents[idx_texture_name-200:idx_texture_name+200])
    if idx_before_gsDPLoadTLUT >= 0 and idx_after_gsDPLoadTLUT >= 0:
        if abs(idx_texture_name - idx_before_gsDPLoadTLUT) < abs(idx_after_gsDPLoadTLUT - idx_texture_name):
            idx_gsDPLoadTLUT = idx_before_gsDPLoadTLUT
        else:
            idx_gsDPLoadTLUT = idx_after_gsDPLoadTLUT
    elif idx_before_gsDPLoadTLUT >= 0:
        idx_gsDPLoadTLUT = idx_before_gsDPLoadTLUT
    else:
        idx_gsDPLoadTLUT = idx_after_gsDPLoadTLUT
    m = re.compile(r'gsDPLoadTLUT_pal(?:16\(\d+,\s*|256\()([^)]+)\)').match(contents, idx_gsDPLoadTLUT)
    if m.start() != idx_gsDPLoadTLUT:
        fail('While searching for the palette used by', texture_name, ', initially found gsDPLoadTLUT_pal* at', idx_gsDPLoadTLUT, 'but regex matched at', m.start(), 'in', file_path)
    return m.group(1)

def getTlutSymbol(file_type_folder, file_folder, file_name, file_segment, texture_name, texture_format):
    file_path = os.path.join('assets', file_type_folder, file_folder, file_name + '.c')
    with open(file_path) as f:
        contents = f.read()
    idx_texture_name = contents.find('(' + texture_name)
    if idx_texture_name < 0:
        print('Cannot find', '(' + texture_name, 'in', file_path)
        return None
    indices_texture_name = []
    tlut_symbols = set()
    while not idx_texture_name < 0:
        tlut_symbol = getTlutUsedNear(file_path, contents, texture_name, texture_format, idx_texture_name)
        if tlut_symbol is None:
            fail('getTlutUsedNear() is None')
        tlut_symbols.add(tlut_symbol)
        idx_texture_name = contents.find('(' + texture_name, idx_texture_name+1)
    if len(tlut_symbols) > 1:
        fail('Found several tluts in search', '(' + texture_name, 'in', file_path, tlut_symbols)
    return list(tlut_symbols)[0]

for root, dirs, files in os.walk('assets/xml'):
    for name in files:
        if name in (
            # todo check if these are totally or just partially commented out
            # do we want to "fix" these at all?
            'object_ahg.xml', 'object_bji.xml', 'object_oF1s.xml', 'object_cne.xml', 'object_kw1.xml', # contents commented out
            'object_boj.xml', # partially commented out
            'map_48x85_static.xml', # probably not CI? I4 or IA4? code doesn't make sense to me
        ):
            print('FILE SKIP!', name)
            continue
        file = os.path.join(root, name)
        with open(file) as f:
            xmlContents = f.read()
        desc_files = []
        # gameplay_field_keep feels like being special and has a random space after "Segment=":
        # <File Name="gameplay_field_keep" Segment= "5">
        for m in re.finditer(r'<File\s+Name="([^"]*)".+?Segment=\s*"(\d+)"\s*>', xmlContents):
            desc_files.append((m.start(), m.group(1), int(m.group(2))))
        if len(desc_files) != xmlContents.count('<File'):
            print(xmlContents[:100])
            fail('May have missed a <File> in', file, ', found', xmlContents.count('<File'), 'occurences of "<File" but regex found', len(desc_files))
        tlutTextures = {}
        for m in re.finditer(r'<Texture\s+Name="([^"]*)".+?Format="(?:rgb5a1|rgba16)".*?Offset="((?:0x)?[0-9a-fA-F]+)".*?/>', xmlContents):
            for desc_file_start_idx, desc_file_name, desc_file_segment in desc_files:
                if m.start() < desc_file_start_idx:
                    break
                tlut_desc_file_name = desc_file_name
                tlut_desc_file_segment = desc_file_segment
            tlutTextures[m.group(1)] = (desc_file_segment, m.group(2))
        def repl(m):
            texture_symbol = m.group(1)
            search_texture_symbol = texture_symbol
            tex_format = m.group(2)
            for desc_file_start_idx, desc_file_name, desc_file_segment in desc_files:
                if m.start() < desc_file_start_idx:
                    break
                tex_desc_file_name = desc_file_name
                tex_desc_file_segment = desc_file_segment
            s = m.group(0)
            skip = False
            if any(srch in texture_symbol for srch in (
                'gZelda2Eye','gShiekEye','gNabooruEye','gObjOwlEye','gGerudoPurpleEye','gChildZelda1Eye',
                'gRutoChildEye','gChildEponaEye','gGerudoRedEye','gSariaEye','gMalonChildEye','gMidoEye',
                'gEponaEye','gDaruniaEye','gWindmillManEye',
            )):
                search_texture_symbol = '0x08000000'
                #print('EYE 8!', texture_symbol, 'will search for', search_texture_symbol)
            elif any(srch in texture_symbol for srch in ('EyeOpen','EyeHalf','EyeClosed','EyeWide','EyeShut','EyeSad','EyeSurprised','EyeClosing',)):
                print('SKIP!', texture_symbol, '(eye tex detected)')
                skip = True
            if any(srch in texture_symbol for srch in ('gZelda2Mouth','gChildZelda1Mouth','gSariaMouth',)):
                search_texture_symbol = '0x0A000000'
                #print('MOUTH A!', texture_symbol, 'will search for', search_texture_symbol)
            if any(srch in texture_symbol for srch in ('gWindMillManMouth','gRutoChildMouth','gMalonChildNeutralMouthTex','gMalonChildSmilingMouthTex','gMalonChildTalkingMouthTex','gDaruniaMouth',)):
                search_texture_symbol = '0x09000000'
                #print('MOUTH 9!', texture_symbol, 'will search for', search_texture_symbol)
            if texture_symbol.startswith('gMeagmiRightCrumble'):
                search_texture_symbol = '0x08000000'
            if texture_symbol.startswith('gMeagmiLeftCrumble'):
                search_texture_symbol = '0x09000000'
            if texture_symbol.startswith('gDaruniaNose'):
                search_texture_symbol = '0x0A000000'
            if texture_symbol.startswith('gRunningManMouth'):
                search_texture_symbol = '0x08000000'
            if texture_symbol in (
                'gDampeUnkTex', # ?
                'gObjOwlEyeOpenTex', 'gObjOwlEyeHalfTex', 'gObjOwlEyeClosedTex', # object_owl.c uses segment 8 two times with different palettes
                'gWorldMapImageTex', # tlut set in code
                'gRoofMan2TLUT', # this tlut is set to ci8 format for some reason, probably a mistake
            ):
                print('SKIP!', texture_symbol, '(hardcoded skip)')
                skip = True
            if 'TlutOffset' in s or skip:
                return s
            else:
                tlut_symbol = getTlutSymbol(root[len('assets/xml/'):], name[:-len('.xml')], tex_desc_file_name, tex_desc_file_segment, search_texture_symbol, tex_format)
                if tlut_symbol is None:
                    print('SKIP! tlut_symbol is None for tex', texture_symbol, '(search =', search_texture_symbol, ') in', tex_desc_file_name)
                    return s
                if tlut_symbol not in tlutTextures:
                    # TLUT not in xml
                    if tlut_symbol in ('gRoofMan2TLUT',):
                        print('LATE SKIP!', texture_symbol, 'because using', tlut_symbol, '(hardcoded skip)')
                        return s
                    if not tlut_symbol.startswith(tex_desc_file_name + 'TLUT_'):
                        fail('Unknown tlut symbol', tlut_symbol, 'for tex', texture_symbol, 'in', tex_desc_file_name, '(not in', name,'?) and not named like an autogenerated symbol (eg', tex_desc_file_name + 'TLUT_XXXXXX', ' XXXXXX = offset)')
                    tlut_segment = tex_desc_file_segment # the symbol is named with tex_desc_file_name so it must be in the same file/same segment
                    tlut_offset = hex(int(tlut_symbol[len(tex_desc_file_name + 'TLUT_'):], 16))
                else:
                    tlut_segment, tlut_offset = tlutTextures[tlut_symbol]
                if tlut_segment != tex_desc_file_segment:
                    fail('tex', texture_symbol, 'and tlut', tlut_symbol, 'are from different segments')
                if texture_symbol == 'gNabooruEyeOpenTex':
                    print('gNabooruEyeOpenTex tlut:', tlut_offset)
                return s[:-2] + ' TlutOffset="' + tlut_offset + '"/>'
        # object_cs.xml decided to use single quotes ''
        # <Texture Name='gGraveyardKidPantsTex' OutName="pants" Format="ci8" Width="16" Height="16" Offset="0x3C70"/>
        xmlContents = re.sub(r'<Texture\s+Name=[\'"]([^\'"]*)[\'"].+?Format="(ci[48])".*?/>', repl, xmlContents)
        with open(file, 'w') as f:
            f.write(xmlContents)
```

</details>

Then I manually checked with Z64Utils that every .xml it modified found the right TlutOffset, and it did. So here I am

This PR is a reduced version of my [objectdecomp_addmosttlutoffsets branch](https://github.com/Dragorn421/oot/tree/objectdecomp_addmosttlutoffsets), here I only added the objects you added in your PR at https://github.com/zeldaret/oot/pull/815